### PR TITLE
Fix anchor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ collectionView.gemini
 - [x] And More...
 
 # Contents
-- [Animation Types and properties](#anmation-types)
+- [Animation Types and properties](#animation-types)
 - [Usage](#usage)
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Author](#author)
 
-# <a name="anmation-types"> Animation Types and properties
+# <a name="animation-types"> Animation Types and properties
 
 The following animation types are available. See sample code [here](https://github.com/shoheiyokoyama/Gemini/tree/master/Example/Gemini) for details.
 


### PR DESCRIPTION
## Summary
- fix a typo in the table of contents
- update the matching anchor name

## Testing
- `bundle exec pod lib lint --allow-warnings` *(fails: bundler not found)*
- `bundle install --path vendor/bundle` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68457c8c66b48333b0bc4a38c553ed03