### PR TITLE
Fix pitch typo in animation list

### DIFF
--- a/Example/Gemini/ViewControllers/AnimationListViewController.swift
+++ b/Example/Gemini/ViewControllers/AnimationListViewController.swift
@@ -29,12 +29,12 @@ final class AnimationListViewController: UIViewController {
          "Vertical sine wave",
          "Vertical reverse sine wave"],
         // Pitch rotation
-        ["Horizontal pictch up",
-         "Horizontal pictch down",
+        ["Horizontal pitch up",
+         "Horizontal pitch down",
          "Horizontal sine wave",
          "Horizontal reverse sine wave",
-         "Vertical pictch up",
-         "Vertical pictch down",
+         "Vertical pitch up",
+         "Vertical pitch down",
          "Vertical sine wave",
          "Vertical reverse sine wave"],
         // Yaw rotation


### PR DESCRIPTION
## Summary
- fix pitch rotation titles typo

## Testing
- `bundle exec pod lib lint --allow-warnings` *(fails: bundler command not found)*
- `bundle install --path vendor/bundle` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68457d4ba428833387daf1f4b75189ae